### PR TITLE
Use d-editor instead of pagedown-editor

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-pages-form.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-pages-form.hbs
@@ -11,7 +11,7 @@
     {{i18n 'static_pages.body'}}
   </label>
   <div class="col-lg-10">
-    {{pagedown-editor name="body" value=model.body required="true"}}
+    {{d-editor name="body" value=model.body required="true"}}
   </div>
 </div>
 <input type="hidden" name="id" {{bind-attr value=model.id}} id="id" />


### PR DESCRIPTION
@albanlv After updating my local Discourse version I started seeing the following error when trying to load the new/edit page form:

`TypeError: Cannot read property 'helperFunction' of undefined`

It was being thrown when trying to load the `pagedown-editor`:

https://github.com/nukomeet/discourse-static-pages/blob/0e87a6920660ea49b0c3c305bf4a3ee24e86eace/assets/javascripts/discourse/templates/admin/plugins-pages-form.hbs#L14
